### PR TITLE
Fix related nodes

### DIFF
--- a/backend/discovery/edge_helper.py
+++ b/backend/discovery/edge_helper.py
@@ -119,9 +119,10 @@ def _shortest_path_between_tables(tx, from_table, to_table):
     tx_result = tx.run("match (n {source_name: $from_table}), "
                        "(m {source_name: $to_table}), "
                        "p=shortestPath((n)-[r:RELATED|SIBLING*]-(m)) "
-                       "return relationships(p) as result", from_table=from_table, to_table=to_table)
+                       "return p", from_table=from_table, to_table=to_table)
+
     result = []
     for record in tx_result:
-        result.append(record['result'])
+        result.append(record['p'])
     return result
 

--- a/backend/discovery/queries.py
+++ b/backend/discovery/queries.py
@@ -83,25 +83,26 @@ def get_related_between_two_tables(from_table: str, to_table: str) -> list:
     all_links = []
     # Each path contains multiple segments
     # A segment is a relationship between two nodes
-    for segment in paths:
+    for path in paths:
         explanation = f"Table {from_table} and table {to_table} are connected via the following path:"
         link = []
         # Remember the current table, because the traversal is directionless
         # Therefore, we need to find the start node which matches with the previous end node
         current_table = from_table
-        for relation in segment:
+        for relation in path.relationships:
             # We don't follow the sibling edges, only the match (RELATED)
+
             if relation.type == MATCH:
-                if current_table in relation['from_id']:
-                    explanation = f"{explanation} {relation['from_id']} -> {relation['to_id']} ->"
-                    link.append(relation['from_id'])
-                    link.append(relation['to_id'])
-                    current_table = '/'.join(relation['to_id'].split('/')[:-1])
+                if current_table in relation.start_node['id']:
+                    explanation = f"{explanation} {relation.start_node['id']} -> {relation.end_node['id']} ->"
+                    link.append(relation.start_node['id'])
+                    link.append(relation.end_node['id'])
+                    current_table = '/'.join(relation.end_node['id'].split('/')[:-1])
                 else:
-                    explanation = f"{explanation} {relation['to_id']} -> {relation['from_id']} ->"
-                    link.append(relation['to_id'])
-                    link.append(relation['from_id'])
-                    current_table = '/'.join(relation['from_id'].split('/')[:-1])
+                    explanation = f"{explanation} {relation.end_node['id']} -> {relation.start_node['id']} ->"
+                    link.append(relation.end_node['id'])
+                    link.append(relation.start_node['id'])
+                    current_table = '/'.join(relation.start_node['id'].split('/')[:-1])
         # Because of the sibling edges, some paths will be similar to previous
         if link not in all_links:
             all_links.append({'explanation': explanation, 'links': link})


### PR DESCRIPTION
This PR fixes the `/get-related` route, by letting Neo4J return the paths (which come with all properties) instead of just the relations (which do not have node properties in them), and then getting the start/end nodes by using the `start_node` and `end_node` attributes on the relations.