### PR TITLE
Celery reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,8 @@ The following admin-panels are exposed, for inspecting the services:
 - Elasticsearch: `localhost:5000`
 - MinIO server: `localhost:9000`
 
+#### File sharing error
 If you get an error about file sharing on windows, visit [this](https://stackoverflow.com/questions/60754297/docker-compose-failed-to-build-filesharing-has-been-cancelled) thread.
+
+#### Celery hot-reloading on Windows
+On Linux containers that run under Windows, file notifications for watched files in volumes do not function, so celery task hot-reloading is broken. To deal with this, clone [this repository](https://github.com/Archer6621/docker-windows-volume-watcher), and run the batch file `volume_watcher_windows.bat`, which will watch the folders on windows and then send the relevant notifications/events into the celery container.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,3 @@ The following admin-panels are exposed, for inspecting the services:
 
 #### File sharing error
 If you get an error about file sharing on windows, visit [this](https://stackoverflow.com/questions/60754297/docker-compose-failed-to-build-filesharing-has-been-cancelled) thread.
-
-#### Celery hot-reloading on Windows
-On Linux containers that run under Windows, file notifications for watched files in volumes do not function, so celery task hot-reloading is broken. To deal with this, clone [this repository](https://github.com/Archer6621/docker-windows-volume-watcher), and run the batch file `volume_watcher_windows.bat`, which will watch the folders on windows and then send the relevant notifications/events into the celery container.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,4 @@ tensorflow==2.8.0
 scikit-learn==0.24
 pytest==6.2.5
 pyfunctional==1.4.3
+watchdog==2.1.9 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,8 @@ services:
       - PYTHONUNBUFFERED=1
     env_file:
       - .env
-    command: watchmedo auto-restart -d '/backend/utility' -p '*.py' -R -- celery -A backend.celery worker -l INFO --concurrency=2 --max-memory-per-child=2929687
+    # Polling is required because inotify does not work on subfolders of bind mounts
+    command: watchmedo auto-restart --debug-force-polling -d /backend/utility/celery_tasks.py -d /backend/__init__.py -- celery -A backend.celery worker -l INFO --concurrency=2 --max-memory-per-child=2929687
     depends_on:
       - rabbitmq
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - PYTHONUNBUFFERED=1
     env_file:
       - .env
-    command: celery -A backend.celery worker -l INFO --concurrency=2 --max-memory-per-child=2929687
+    command: watchmedo auto-restart -d '/backend/utility' -p '*.py' -R -- celery -A backend.celery worker -l INFO --concurrency=2 --max-memory-per-child=2929687
     depends_on:
       - rabbitmq
 


### PR DESCRIPTION
Adds hot-reloading for celery tasks.

Note that hot-reload can be a bit slow, as you have to wait for celery to restart.