### PR TITLE
Get related and redis bugfixes

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -224,38 +224,48 @@ RelatedTableModel = api.model("RelatedTable", {
 @api.doc(description="Get all the assets on the path connecting the source and the target tables.")
 @api.doc(params={
     'source_asset_id': {'description': 'The id of the asset to get the table from as source', 'in': 'query', 'type': 'string', 'required': 'true'},
-    'target_asset_id': {'description': 'The id of the asset to get the table from as target', 'in': 'query', 'type': 'string', 'required': 'true'},
-
+    'target_asset_ids': {'description': 'The id of the asset to get the table from as target', 'in': 'query', 'type': 'array', 'items': {'type': 'string'}, 'required': 'true'},
 })
 class GetRelatedNodes(Resource):
     @api.response(200, 'Success',
                   api.model("RelatedTables", {"RelatedTables": fields.List(fields.Nested(RelatedTableModel))}))
     @api.response(400, 'Missing asset ids query parameters')
-    @api.response(403, 'Source and target are the same')
+    @api.response(403, 'Source asset id is among target asset ids')
     @api.response(404, 'Table in asset does not exist')
     def get(self):
         source_asset_id = request.args.get("source_asset_id")
-        target_asset_id = request.args.get("target_asset_id")
 
-        if not source_asset_id or not target_asset_id:
+        # Normally we can use Flask's 'getlist', but Flask RestX does not correctly send the query params:
+        # - What it should do is repeat the query param multiple times with different values
+        # - Instead, it puts it as one query param and separates the values by commas...
+        target_asset_ids_string = request.args.get("target_asset_ids")
+
+        if not source_asset_id or not target_asset_ids_string:
             return Response("Please provide both a source asset id and a target asset id as query parameters",
                             status=400)
 
-        if source_asset_id == target_asset_id:
-            return Response("Source and target asset ids should be different", status=403)
+        target_asset_ids = target_asset_ids_string.split(',')
 
-        from_table = search.io_tools.get_table_path_from_asset_id(asset_id)
-        node = discovery.queries.get_node_by_prop(source_name=from_table)
+        if source_asset_id in target_asset_ids:
+            return Response("Source asset id should not be in target asset ids", status=403)
+
+        from_table_path = search.io_tools.get_table_path_from_asset_id(source_asset_id)
+        from_table = search.redis_tools.get_table(from_table_path)
+        node = discovery.queries.get_node_by_prop(source_path=from_table_path)
         if len(node) == 0:
             return Response("Table does not exist", status=404)
 
-        to_table = search.io_tools.get_table_path_from_asset_id(asset_id)
-        node = discovery.queries.get_node_by_prop(source_name=to_table)
-        if len(node) == 0:
-            return Response("Table does not exist", status=404)
-
-        paths = get_related_between_two_tables(from_table, to_table)
-        return Response(json.dumps({"RelatedTables": paths}), mimetype='application/json', status=200)
+        related_tables = []
+        for asset_id in target_asset_ids:
+            logging.info(f"Processing {asset_id}")
+            to_table_path = search.io_tools.get_table_path_from_asset_id(asset_id)
+            to_table = search.redis_tools.get_table(to_table_path)
+            node = discovery.queries.get_node_by_prop(source_path=to_table_path)
+            if len(node) > 0:
+                related_tables += get_related_between_two_tables(from_table, to_table)
+            else:
+                logging.warning(f"Table at path '{to_table_path}' does not exist")
+        return Response(json.dumps({"RelatedTables": related_tables}), mimetype='application/json', status=200)
 
 
 # Apparently we need to make models for every nested field...
@@ -286,13 +296,14 @@ class GetJoinable(Resource):
         asset_id = args.get("asset_id")
         if asset_id is None:
             return Response("Please provide an asset id as query parameter", status=400)
-
+ 
         table_path = search.io_tools.get_table_path_from_asset_id(asset_id)
-        node = discovery.queries.get_node_by_prop(source_name=table_path)
+        node = discovery.queries.get_node_by_prop(source_path=table_path)
         if len(node) == 0:
             return Response("Table or asset does not exist", status=404)
 
-        return Response(json.dumps({"JoinableTables": discovery.queries.get_joinable(table_path)}),
+        table = search.redis_tools.get_table(table_path)
+        return Response(json.dumps({"JoinableTables": discovery.queries.get_joinable(table)}),
                         mimetype='application/json', status=200)
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -264,7 +264,7 @@ class GetRelatedNodes(Resource):
             if len(node) > 0:
                 related_tables += get_related_between_two_tables(from_table, to_table)
             else:
-                logging.warning(f"Table at path '{to_table_path}' does not exist")
+                logging.warning(f"Given asset '{asset_id}' does not exist")
         return Response(json.dumps({"RelatedTables": related_tables}), mimetype='application/json', status=200)
 
 

--- a/backend/clients/redis.py
+++ b/backend/clients/redis.py
@@ -20,7 +20,7 @@ def get_client() -> StrictRedis:
 def initialize():
     logging.info("Initializing Redis client...")
     table_schema = (
-        TextField("$.table.path", as_name="path")
+        TextField("$.table.id", as_name="id")
     )
     task_schema = (
         TextField("$.task.id", as_name="id")

--- a/backend/discovery/edge_helper.py
+++ b/backend/discovery/edge_helper.py
@@ -116,8 +116,8 @@ def _delete_relation_by_id(tx, relation_id):
 
 
 def _shortest_path_between_tables(tx, from_table, to_table):
-    tx_result = tx.run("match (n {source_name: $from_table}), "
-                       "(m {source_name: $to_table}), "
+    tx_result = tx.run("match (n {source_path: $from_table}), "
+                       "(m {source_path: $to_table}), "
                        "p=shortestPath((n)-[r:RELATED|SIBLING*]-(m)) "
                        "return p", from_table=from_table, to_table=to_table)
 

--- a/backend/discovery/node_helper.py
+++ b/backend/discovery/node_helper.py
@@ -44,9 +44,9 @@ def get_siblings(node_id):
     return nodes
 
 
-def get_nodes_by_table_name(source_name):
+def get_nodes_by_table_path(source_path):
     with neo.get_client().session() as session:
-        nodes = session.write_transaction(_get_nodes_by_table_name, source_name)
+        nodes = session.write_transaction(_get_nodes_by_table_path, source_path)
     return nodes
 
 
@@ -80,10 +80,10 @@ def delete_all():
     return node
 
 
-def _get_nodes_by_table_name(tx, source_name):
+def _get_nodes_by_table_path(tx, source_path):
     tx_result = tx.run("MATCH (n) "
-                       "WHERE n.source_name = $source_name "
-                       "RETURN n as result", source_name=source_name)
+                       "WHERE n.source_path = $source_path "
+                       "RETURN n as result", source_path=source_path)
 
     result = []
     for record in tx_result:

--- a/backend/discovery/queries.py
+++ b/backend/discovery/queries.py
@@ -8,6 +8,8 @@ from .edge_helper import shortest_path_between_tables
 from .relation_types import MATCH
 from .utilities import process_relation, process_node
 
+from typing import Dict, Any, List
+
 
 def get_nodes():
     return node_helper.get_all()
@@ -30,7 +32,8 @@ def get_related_nodes(node_id: str):
             nodes = processed_result
         else:
             nodes_id = list(map(lambda z: z['id'], nodes))
-            temp = list(filter(lambda x: x['id'] not in nodes_id, processed_result))
+            temp = list(filter(lambda x: x['id']
+                               not in nodes_id, processed_result))
             nodes = nodes + temp
 
         if len(related_nodes) == 0:
@@ -38,15 +41,18 @@ def get_related_nodes(node_id: str):
         else:
             nodes_id = list(map(lambda z: z['id'], related_nodes))
             nodes = list(filter(lambda x: x['id'] not in nodes_id, nodes))
-            temp = list(filter(lambda x: x['id'] not in nodes_id, processed_result))
+            temp = list(filter(lambda x: x['id']
+                               not in nodes_id, processed_result))
             related_nodes = related_nodes + temp
 
     return related_nodes
 
 
-def get_joinable(table_name: str):
+def get_joinable(table: Dict[str, Any]):
+    table_path = table['path']
+    table_name = table['name']
     # Get all the nodes belonging to the given table
-    nodes = node_helper.get_nodes_by_table_name(table_name)
+    nodes = node_helper.get_nodes_by_table_path(table_path)
     # Simplify the object (only keep the table path, column name and column id)
     siblings = process_node(nodes)
 
@@ -58,20 +64,23 @@ def get_joinable(table_name: str):
         # If the node has connection, transform the result into something useful for us
         # { table_name: {PK: { from_id: <id>, to_id: <id> }, RELATED: <threshold>} ... }
         if len(related_nodes) > 0:
-            tables = process_relation(table_name, related_nodes)
+            tables = process_relation(table_path, table_name, related_nodes)
             for related_table in tables:
                 related_table_name = related_table["table_name"]
-                if related_table_name not in joinable_tables:
-                    joinable_tables[related_table_name] = {"matches": []}
-                related_table.pop("table_name")  # We move this one level up
-                joinable_tables[related_table_name]["matches"].append(related_table)
-                joinable_tables[related_table_name]["table_name"] = related_table_name
-            logging.info(joinable_tables[related_table_name]["matches"])
-            joinable_tables[related_table_name]["matches"] = list(
-                sorted(joinable_tables[related_table_name]["matches"], key=lambda x: -x["RELATED"]["coma"] if "coma" in x["RELATED"] else 0))
+                related_table_path = related_table["table_path"]
+                if related_table_path not in joinable_tables:
+                    joinable_tables[related_table_path] = {"matches": []}
+                related_table.pop("table_path")  # We move this one level up
+                joinable_tables[related_table_path]["matches"].append(
+                    related_table)
+                joinable_tables[related_table_path]["table_name"] = related_table_name
+                joinable_tables[related_table_path]["table_path"] = related_table_path
+            logging.info(joinable_tables[related_table_path]["matches"])
+            joinable_tables[related_table_path]["matches"] = list(
+                sorted(joinable_tables[related_table_path]["matches"], key=lambda x: -x["RELATED"]["coma"] if "coma" in x["RELATED"] else 0))
 
     joinable_tables_sorted = sorted(list(joinable_tables.values()), key=lambda x: (
-    -len(x["matches"]), -np.mean([x["RELATED"]["coma"] if "coma" in x["RELATED"] else 0 for x in x["matches"]])))
+        -len(x["matches"]), -np.mean([x["RELATED"]["coma"] if "coma" in x["RELATED"] else 0 for x in x["matches"]])))
 
     return joinable_tables_sorted
 
@@ -80,7 +89,8 @@ def delete_spurious_connections():
     # Get all relations ([ [nr of coma properties, relations] ])
     relations = edge_helper.get_related_relations()
     # Filter out the relations with coma (aka Valentine matcher) property
-    no_match_relations = list(map(lambda x: x[1], filter(lambda x: x[0] == 0, relations)))
+    no_match_relations = list(
+        map(lambda x: x[1], filter(lambda x: x[0] == 0, relations)))
     # For each relation, get the id and delete it
     ids = []
     for relation in no_match_relations:
@@ -89,18 +99,23 @@ def delete_spurious_connections():
     return ids
 
 
-def get_related_between_two_tables(from_table: str, to_table: str) -> list:
+def get_related_between_two_tables(from_table: Dict[str, Any], to_table: Dict[str, Any]) -> List[Dict[str, Any]]:
+    from_table_path = from_table['path']
+    from_table_name = from_table['name']
+    to_table_path = to_table['path']
+    to_table_name = to_table['name']
+
     # Get all shortest path between the two tables
-    paths = shortest_path_between_tables(from_table, to_table)
+    paths = shortest_path_between_tables(from_table_path, to_table_path)
     all_links = []
     # Each path contains multiple segments
     # A segment is a relationship between two nodes
     for path in paths:
-        explanation = f"Table {from_table} and table {to_table} are connected via the following path:"
+        explanation = f"Table {from_table_name} and table {to_table_name} are connected via the following path:"
         link = []
         # Remember the current table, because the traversal is directionless
         # Therefore, we need to find the start node which matches with the previous end node
-        current_table = from_table
+        current_table = from_table_path
         for relation in path.relationships:
             # We don't follow the sibling edges, only the match (RELATED)
 
@@ -109,12 +124,14 @@ def get_related_between_two_tables(from_table: str, to_table: str) -> list:
                     explanation = f"{explanation} {relation.start_node['id']} -> {relation.end_node['id']} ->"
                     link.append(relation.start_node['id'])
                     link.append(relation.end_node['id'])
-                    current_table = '/'.join(relation.end_node['id'].split('/')[:-1])
+                    current_table = '/'.join(
+                        relation.end_node['id'].split('/')[:-1])
                 else:
                     explanation = f"{explanation} {relation.end_node['id']} -> {relation.start_node['id']} ->"
                     link.append(relation.end_node['id'])
                     link.append(relation.start_node['id'])
-                    current_table = '/'.join(relation.start_node['id'].split('/')[:-1])
+                    current_table = '/'.join(
+                        relation.start_node['id'].split('/')[:-1])
         # Because of the sibling edges, some paths will be similar to previous
         connection = {'explanation': explanation, 'links': link}
         if connection not in all_links:

--- a/backend/discovery/utilities.py
+++ b/backend/discovery/utilities.py
@@ -6,22 +6,23 @@ from backend.utility.display import log_format
 logging.basicConfig(format=log_format, level=logging.INFO)
 
 
-def process_relation(base_table: str, result: List[Dict[str, str]]) -> List[Dict[str, Union[Dict[str, str], str]]]:
+def process_relation(base_table_path: str, base_table_name: str, result: List[Dict[str, str]]) -> List[Dict[str, Union[Dict[str, str], str]]]:
     tables = []
     assets = []
     for relation in result:
         table = {}
         # Get connected node to the sibling. A relation is only between 2 nodes, so filter outputs one result
         related_node = list(filter(lambda x: x.get('id') is not None, relation.nodes))[0]
-        table['table_name'] = related_node.get('source_name')
-        if table['table_name'] in assets:
-            logging.info(f"IN ASSETS: {table['table_name']}")
+        table['table_path'] = related_node.get('source_path')
+        table['table_name'] = related_node.get('source_name')  # Needed for display
+        if table['table_path'] in assets:
+            logging.info(f"IN ASSETS: {table['table_path']}")
             continue
 
-        assets.append(table['table_name'])
-        logging.info(f"TABLE NAME: {table['table_name']}")
+        assets.append(table['table_path'])
+        logging.info(f"TABLE PATH: {table['table_path']}")
 
-        explanation = f"Table {base_table} is joinable with table {related_node.get('source_name')}"
+        explanation = f"Table {base_table_path} is joinable with table {related_node.get('source_name')}"
 
         if "to_id" in relation:
             table["PK"] = {'from_id': relation['from_id'], 'to_id': relation['to_id']}

--- a/backend/search/io_tools.py
+++ b/backend/search/io_tools.py
@@ -53,8 +53,8 @@ def get_df(table_path: str, rows=None) -> pd.DataFrame:
         header=0,
         engine="python",
         # encoding="utf8",
-        # quotechar='"',
-        # escapechar='\\',
+        quotechar='"',
+        escapechar='\\',
         nrows=rows,
         sep=None,
     )

--- a/backend/search/redis_tools.py
+++ b/backend/search/redis_tools.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import hashlib
 
 from ast import literal_eval
 # Typing
@@ -13,16 +14,22 @@ from ..clients import redis
 from ..utility.typing import Table
 
 
+def _deterministic_hash(string: str) -> str:
+    return hashlib.sha256(str.encode(string)).hexdigest()
+
+
 def save_celery_task(task_id: str, task_tuple: str) -> None:
     """
     Saves a Celery task as a tuple tree generated from 'as_tuple' in the database under the given task_id.
     """
+    task_id_hash = _deterministic_hash(task_id)
     redis.get_client().json().set(
-        f"task:{task_id.replace('-', '')}",  # See: https://forum.redis.com/t/query-with-dash-is-treated-as-negation/119/12
+        task_id_hash,
         Path.root_path(),
         {
             "task": {
-                "id": task_id.replace('-', ''),
+                "id": task_id_hash,
+                "name": task_id,
                 "task_tuple": str(task_tuple)
             }
         }
@@ -33,7 +40,7 @@ def get_celery_task(task_id: str) -> Optional[tuple]:
     """
     Gets a Celery task tuple tree if the task exists, otherwise returns None.
     """
-    query = Query(f"@id:{task_id.replace('-', '')}")
+    query = Query(f"@id:{_deterministic_hash(task_id)}")
     res = redis.get_client().ft(index_name="task").search(query)
     first = None
     if res.docs:
@@ -45,11 +52,13 @@ def add_table(table_name: str, table_path: str, column_count: int, nodes: Dict[s
     """
     Adds a table with some useful metadata to the database.
     """
+    table_path_hash = _deterministic_hash(table_path)
     redis.get_client().json().set(
-        f"table:{table_path}",
+        f"table:{table_path_hash}",
         Path.root_path(),
         {
             "table": {
+                "id": table_path_hash,
                 "path": table_path,
                 "name": table_name,
                 "column_count": column_count,
@@ -72,7 +81,8 @@ def get_table(table_path: str) -> Optional[Table]:
     """
     Gets table metadata given the table path, or None if nothing was found.
     """
-    query = Query(f"@path:{table_path}")
+    table_path_hash = _deterministic_hash(table_path)
+    query = Query(f"@id:{table_path_hash}")
     res = redis.get_client().ft(index_name="table").search(query)
     first = None
     if res.docs:

--- a/backend/utility/celery_tasks.py
+++ b/backend/utility/celery_tasks.py
@@ -58,6 +58,7 @@ def add_table(table_path: str):
     Adds a table at the given table path to Daisy's databases.
     """
     table_name = table_path.split('/')[-1]
+    logging.info(f"- Parsing table at {table_path} into DataFrame")
     df = search.io_tools.get_df(table_path)
     # Split the dataframe into a new dataframe for each column
     logging.info(f"- Adding whole table metadata to neo4j for {table_path}")


### PR DESCRIPTION
**Changes and fixes:**
- Small fix for reading dataframes: now checks for quotes `"` and `\` escapes again 
- Redis tools now uses deterministically hashed versions of the paths now as IDs for the table metadata and tasks, to avoid getting caught by tokenization
   - See: https://redis.io/docs/stack/search/reference/escaping/ 
- Made the discovery part of the backend work with table paths instead of table names as identifiers, which fixes both `get-joinable` and `get-related`
- Made `get-related` API endpoint accept an array of asset IDs instead of just a single target asset