### PR TITLE
Updated get-related

### DIFF
--- a/backend/discovery/queries.py
+++ b/backend/discovery/queries.py
@@ -61,7 +61,7 @@ def get_joinable(table: Dict[str, Any]):
     siblings = process_node(nodes)
     with open(ROOT_FOLDER / 'pids-of-active-assets.txt') as f:
         active_pids = [line.rstrip('\n') for line in f]
-    print(f"Active pids: {len(active_pids)} \n {active_pids}")
+    print(f"Active pids: {len(active_pids)}")
     joinable_tables = {}
     for sib in siblings:
         # Get all the nodes connected to a sibling via RELATED edge


### PR DESCRIPTION
Get related accepts asset names and asset id as params, instead of only working with IDs

Fixes # .

Changes proposed in this pull request:
- get-related works with asset names
- removed a large print 

@OpertusMundi/developers
